### PR TITLE
Add Support different admin url

### DIFF
--- a/content/templates/viewIndex.xsl
+++ b/content/templates/viewIndex.xsl
@@ -46,7 +46,7 @@
 <xsl:template match="templates/entry">
 	<tr>
 		<td>
-			<a href="{concat($root, '/symphony/extension/email_template_manager/templates/edit/', handle, '/')}"><xsl:value-of select="name"/></a>
+			<a href="{concat($symphony-url, '/extension/email_template_manager/templates/edit/', handle, '/')}"><xsl:value-of select="name"/></a>
 			<input name="items[{handle}]" type="checkbox"/>
 		</td>
 		<td>
@@ -56,7 +56,7 @@
 </xsl:template>
 
 <xsl:template match="templates/entry/layouts/*" mode="preview">
-	<a href="{concat($root, '/symphony/extension/email_template_manager/templates/preview/', ../../handle, '/', local-name(), '/')}" style="text-transform:uppercase" target="_blank"><xsl:value-of select="local-name()"/></a>
+	<a href="{concat($symphony-url, '/extension/email_template_manager/templates/preview/', ../../handle, '/', local-name(), '/')}" style="text-transform:uppercase" target="_blank"><xsl:value-of select="local-name()"/></a>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/lib/class.extensionpage.php
+++ b/lib/class.extensionpage.php
@@ -47,6 +47,7 @@ class ExtensionPage extends AdministrationPage
                     'timezone' => DateTimeObj::get('P'),
                     'website-name' => Symphony::Configuration()->get('sitename', 'general'),
                     'root' => URL,
+                    'symphony-url' => SYMPHONY_URL,
                     'workspace' => URL . '/workspace',
                     'current-page' => strtolower($this->_type) . ucfirst($this->_function),
                     'current-path' => $current_path,


### PR DESCRIPTION
The XSLT templates do not know if admin url is using `/symphony` or not so added a new `symphony-url` parameter which is used in the XSL template instead of hardcoding `/symphony`